### PR TITLE
feat: implement concise summary format for test reports

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm install)",
+      "Bash(npm run test:*)",
+      "Bash(npm run build*)",
+      "WebSearch",
+      "WebFetch(domain:playwright.dev)",
+      "Bash(tree:*)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ For optimal debugging, use:
 | `maxErrorLength`       | number  | `5000`                            | Maximum error message length                                                            |
 | `singleReportFile`     | boolean | `true`                            | Generate single consolidated error-context.md file                                      |
 | `capturePageState`     | boolean | `true`                            | Capture page state on failure (URL, title, available selectors, visible text)           |
-| `verboseErrors`        | boolean | `true`                            | Include detailed error information                                                      |
+| `verboseErrors`        | boolean | `true`                            | Show detailed error list after summary. Set to `false` for only concise summary         |
 | `maxInlineErrors`      | number  | `5`                               | Maximum number of errors to show in console output                                      |
 | `showCodeSnippet`      | boolean | `true`                            | Show code snippet at error location                                                     |
 
@@ -129,16 +129,27 @@ Each failure report includes:
 
 ### Console Output Example
 
-The reporter now shows dot progress for test execution, followed by failed test names, and detailed failure sections with a summary:
+The reporter shows a concise summary at the end of test execution:
 
 ```
 Running 16 tests using 4 workers
 
 ·F·F·F-FFFF·FFFFF
 
-  ✘   test/e2e/reporter-demo.spec.ts:16:7 › Reporter Core Features › assertion failure with context (583ms)
-  ✘   test/e2e/reporter-demo.spec.ts:23:7 › Reporter Core Features › console errors capture (2769ms)
-  ✘   test/e2e/reporter-demo.spec.ts:9:7 › Reporter Core Features › element not found - suggestions (2764ms)
+E2E Test Run: 1/16 passed (15 failed/skipped) in 3.1s
+
+  FAILED (15):
+    ✗ reporter-demo.spec.ts:16 - Reporter Core Features - assertion failure with context - Expected "Expected Title", got "Actual Title"
+    ✗ reporter-demo.spec.ts:23 - Reporter Core Features - console errors capture - Uncaught exception
+    ✗ reporter-demo.spec.ts:9 - Reporter Core Features - element not found - suggestions - Element not found: [.non-existent-selector]
+
+  See for failed test details: ./test-report-for-coding-agents/
+```
+
+When `verboseErrors: true` (default), detailed error information follows:
+
+```
+### Detailed Failures
 
   ## 1) test/e2e/reporter-demo.spec.ts:20:7 › Reporter Core Features › assertion failure with context
      Duration: 583ms
@@ -162,13 +173,22 @@ Running 16 tests using 4 workers
 
   📝 **Full Error Context:** test-report-for-coding-agents/reporter-core-features-assertion-failure-with-context-4/report.md
 
-15 failed
-1 passed
-16 total
-Finished in 3.1s
+```
+
+### Summary Format Features
+
+The new concise summary format provides:
+
+- **One-line overview**: Shows passed/failed/skipped counts and total duration
+- **Failed tests only**: Lists only failed tests with file:line, test name, and brief error
+- **Skipped tests**: Shows skipped tests when present
+- **Report directory**: Points to detailed reports using your configured `outputDir`
+
+To show only the summary without detailed errors, set `verboseErrors: false` in your configuration
 
 📝 Detailed error report: test-report-for-coding-agents/all-failures.md
-```
+
+````
 
 ### Integration with AI/LLM Agents
 
@@ -202,7 +222,7 @@ test('user can complete checkout', async ({ page }) => {
   // Screenshots and available selectors captured on failure
   await expect(page.locator('.checkout-success')).toBeVisible();
 });
-```
+````
 
 ## Development
 

--- a/src/formatters/summary.ts
+++ b/src/formatters/summary.ts
@@ -1,6 +1,8 @@
 import { TestSummary, FailureContext } from '../types';
 
 export class SummaryFormatter {
+  constructor(private outputDir: string = 'test-report-for-coding-agents') {}
+
   formatSummary(summary: TestSummary, startTime: number): string {
     const duration = ((Date.now() - startTime) / 1000).toFixed(1);
     const totalRun = summary.passed + summary.failed + summary.skipped;
@@ -19,16 +21,16 @@ export class SummaryFormatter {
     // Failed tests section
     if (summary.failed > 0) {
       output += `\n  FAILED (${summary.failed}):\n`;
-      const failedTests = summary.failures.filter(f =>
-        f.error?.message && !this.isSkippedTest(f)
+      const failedTests = summary.failures.filter(
+        (f) => f.error?.message && !this.isSkippedTest(f)
       );
 
-      failedTests.forEach(failure => {
+      failedTests.forEach((failure) => {
         const fileName = failure.testFile.replace(process.cwd() + '/', '');
         const errorType = this.extractErrorType(failure);
-        const testName = failure.suiteName ?
-          `${failure.suiteName} - ${failure.testTitle}` :
-          failure.testTitle;
+        const testName = failure.suiteName
+          ? `${failure.suiteName} - ${failure.testTitle}`
+          : failure.testTitle;
 
         output += `    ✗ ${fileName}:${failure.lineNumber || '?'} - ${testName} - ${errorType}\n`;
       });
@@ -40,15 +42,15 @@ export class SummaryFormatter {
       // Note: We don't have direct access to skipped test details in the failures array
       // since Playwright doesn't capture them as failures. This is a limitation.
       // For now, we'll check if any failures might be skip-related
-      const skippedTests = summary.failures.filter(f => this.isSkippedTest(f));
+      const skippedTests = summary.failures.filter((f) => this.isSkippedTest(f));
 
       if (skippedTests.length > 0) {
-        skippedTests.forEach(failure => {
+        skippedTests.forEach((failure) => {
           const fileName = failure.testFile.replace(process.cwd() + '/', '');
           const skipReason = this.extractSkipReason(failure);
-          const testName = failure.suiteName ?
-            `${failure.suiteName} - ${failure.testTitle}` :
-            failure.testTitle;
+          const testName = failure.suiteName
+            ? `${failure.suiteName} - ${failure.testTitle}`
+            : failure.testTitle;
 
           output += `    ⊘ ${fileName}:${failure.lineNumber || '?'} - ${testName} - ${skipReason}\n`;
         });
@@ -60,7 +62,9 @@ export class SummaryFormatter {
 
     // Add pointer to detailed reports
     if (summary.failed > 0) {
-      output += `\n  See for failed test details: ./test-report-for-coding-agents/\n`;
+      // Use relative path from current working directory
+      const relativePath = this.outputDir.startsWith('./') ? this.outputDir : `./${this.outputDir}`;
+      output += `\n  See for failed test details: ${relativePath}/\n`;
     }
 
     return output;
@@ -126,10 +130,12 @@ export class SummaryFormatter {
 
   private isSkippedTest(failure: FailureContext): boolean {
     const message = failure.error?.message?.toLowerCase() || '';
-    return message.includes('skip') ||
-           message.includes('dependency failed') ||
-           message.includes('setup failed') ||
-           message.includes('condition not met');
+    return (
+      message.includes('skip') ||
+      message.includes('dependency failed') ||
+      message.includes('setup failed') ||
+      message.includes('condition not met')
+    );
   }
 
   private extractSkipReason(failure: FailureContext): string {

--- a/src/formatters/summary.ts
+++ b/src/formatters/summary.ts
@@ -1,0 +1,156 @@
+import { TestSummary, FailureContext } from '../types';
+
+export class SummaryFormatter {
+  formatSummary(summary: TestSummary, startTime: number): string {
+    const duration = ((Date.now() - startTime) / 1000).toFixed(1);
+    const totalRun = summary.passed + summary.failed + summary.skipped;
+
+    // Build the one-line summary
+    let output = '';
+
+    // Main summary line
+    const failedAndSkipped = summary.failed + summary.skipped;
+    if (failedAndSkipped > 0) {
+      output += `E2E Test Run: ${summary.passed}/${totalRun} passed (${failedAndSkipped} failed/skipped) in ${duration}s\n`;
+    } else {
+      output += `E2E Test Run: ${summary.passed}/${totalRun} passed in ${duration}s\n`;
+    }
+
+    // Failed tests section
+    if (summary.failed > 0) {
+      output += `\n  FAILED (${summary.failed}):\n`;
+      const failedTests = summary.failures.filter(f =>
+        f.error?.message && !this.isSkippedTest(f)
+      );
+
+      failedTests.forEach(failure => {
+        const fileName = failure.testFile.replace(process.cwd() + '/', '');
+        const errorType = this.extractErrorType(failure);
+        const testName = failure.suiteName ?
+          `${failure.suiteName} - ${failure.testTitle}` :
+          failure.testTitle;
+
+        output += `    ✗ ${fileName}:${failure.lineNumber || '?'} - ${testName} - ${errorType}\n`;
+      });
+    }
+
+    // Skipped tests section
+    if (summary.skipped > 0) {
+      output += `\n  SKIPPED (${summary.skipped}):\n`;
+      // Note: We don't have direct access to skipped test details in the failures array
+      // since Playwright doesn't capture them as failures. This is a limitation.
+      // For now, we'll check if any failures might be skip-related
+      const skippedTests = summary.failures.filter(f => this.isSkippedTest(f));
+
+      if (skippedTests.length > 0) {
+        skippedTests.forEach(failure => {
+          const fileName = failure.testFile.replace(process.cwd() + '/', '');
+          const skipReason = this.extractSkipReason(failure);
+          const testName = failure.suiteName ?
+            `${failure.suiteName} - ${failure.testTitle}` :
+            failure.testTitle;
+
+          output += `    ⊘ ${fileName}:${failure.lineNumber || '?'} - ${testName} - ${skipReason}\n`;
+        });
+      } else {
+        // Generic message when we don't have skip details
+        output += `    ⊘ ${summary.skipped} test${summary.skipped > 1 ? 's' : ''} skipped\n`;
+      }
+    }
+
+    // Add pointer to detailed reports
+    if (summary.failed > 0) {
+      output += `\n  See for failed test details: ./test-report-for-coding-agents/\n`;
+    }
+
+    return output;
+  }
+
+  private extractErrorType(failure: FailureContext): string {
+    const message = failure.error?.message || '';
+
+    // Check for timeout
+    if (message.includes('Timeout') || message.includes('exceeded')) {
+      // Try to extract the selector or action
+      const selectorMatch = message.match(/locator\(['"](.+?)['"]\)/);
+      if (selectorMatch) {
+        return `Timeout: [${selectorMatch[1]}]`;
+      }
+      const actionMatch = message.match(/waiting for (.+?)[\s\n]/);
+      if (actionMatch) {
+        return `Timeout: ${actionMatch[1]}`;
+      }
+      return 'Timeout';
+    }
+
+    // Check for assertion/expect errors
+    if (message.includes('expect') || message.includes('Expected')) {
+      // Try to extract expected vs actual
+      const expectedMatch = message.match(/Expected (.+?), (?:but )?(?:received|got) (.+?)[\s\n.]/);
+      if (expectedMatch) {
+        return `Expected ${expectedMatch[1]}, got ${expectedMatch[2]}`;
+      }
+      return 'Assertion failed';
+    }
+
+    // Check for element not found
+    if (message.includes('not found') || message.includes('no element')) {
+      const selectorMatch = message.match(/locator\(['"](.+?)['"]\)/);
+      if (selectorMatch) {
+        return `Element not found: [${selectorMatch[1]}]`;
+      }
+      return 'Element not found';
+    }
+
+    // Check for other common error types
+    if (message.includes('constraint violation')) {
+      return 'constraint violation';
+    }
+
+    if (message.includes('Network') || message.includes('fetch')) {
+      return 'Network error';
+    }
+
+    if (message.includes('navigation')) {
+      return 'Navigation failed';
+    }
+
+    // Return first line of error or generic message
+    const firstLine = message.split('\n')[0];
+    if (firstLine && firstLine.length < 50) {
+      return firstLine;
+    }
+
+    return 'Test failed';
+  }
+
+  private isSkippedTest(failure: FailureContext): boolean {
+    const message = failure.error?.message?.toLowerCase() || '';
+    return message.includes('skip') ||
+           message.includes('dependency failed') ||
+           message.includes('setup failed') ||
+           message.includes('condition not met');
+  }
+
+  private extractSkipReason(failure: FailureContext): string {
+    const message = failure.error?.message?.toLowerCase() || '';
+
+    if (message.includes('dependency failed')) {
+      return 'dependency failed';
+    }
+
+    if (message.includes('setup failed')) {
+      return 'setup failed';
+    }
+
+    if (message.includes('condition not met')) {
+      return 'condition not met';
+    }
+
+    if (message.includes('skip')) {
+      return 'skipped';
+    }
+
+    return 'unknown reason';
+  }
+}

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -107,7 +107,7 @@ export class CodingAgentReporter implements Reporter {
 
     this.consoleFormatter = new ConsoleFormatter(formatterOptions);
     this.markdownFormatter = new MarkdownFormatter(formatterOptions);
-    this.summaryFormatter = new SummaryFormatter();
+    this.summaryFormatter = new SummaryFormatter(this.options.outputDir);
   }
 
   printsToStdio(): boolean {

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -11,6 +11,7 @@ import * as path from 'path';
 import { CodingAgentReporterOptions, FailureContext, TestSummary } from './types';
 import { ConsoleFormatter } from './formatters/console';
 import { MarkdownFormatter } from './formatters/markdown';
+import { SummaryFormatter } from './formatters/summary';
 import { FormatterOptions } from './formatters/base';
 
 // Constants
@@ -29,6 +30,7 @@ export class CodingAgentReporter implements Reporter {
   private workers: number = 1;
   private consoleFormatter: ConsoleFormatter;
   private markdownFormatter: MarkdownFormatter;
+  private summaryFormatter: SummaryFormatter;
   private dotColumn: number = 0;
   private failedTestsForDotMode: Array<{ test: TestCase; result: TestResult }> = [];
 
@@ -105,6 +107,7 @@ export class CodingAgentReporter implements Reporter {
 
     this.consoleFormatter = new ConsoleFormatter(formatterOptions);
     this.markdownFormatter = new MarkdownFormatter(formatterOptions);
+    this.summaryFormatter = new SummaryFormatter();
   }
 
   printsToStdio(): boolean {
@@ -568,43 +571,19 @@ export class CodingAgentReporter implements Reporter {
       console.log('');
     }
 
-    // Print failed test names immediately after dots (before detailed failures)
-    if (!this.options.silent && this.failedTestsForDotMode.length > 0) {
+    // Print the new summary format first
+    if (!this.options.silent) {
       console.log('');
-      for (const { test, result } of this.failedTestsForDotMode) {
-        const fileName = test.location.file.replace(process.cwd() + '/', '');
-        const duration = result.duration ? ` (${result.duration}ms)` : '';
-        const testPath = `${fileName}:${test.location.line}:${test.location.column}`;
-        const suiteName = test.parent.title || '';
-
-        console.log(`  \x1b[31m✘\x1b[0m   ${testPath} › ${suiteName} › ${test.title}${duration}`);
-      }
+      const summary = this.summaryFormatter.formatSummary(this.testSummary, this.startTime);
+      console.log(summary);
     }
 
     await this.generateMarkdownReports();
 
-    if (!this.options.silent && this.failures.length > 0) {
-      console.log('');
+    // Optionally print detailed failures if verboseErrors is true and not in silent mode
+    if (!this.options.silent && this.options.verboseErrors && this.failures.length > 0) {
+      console.log('\n### Detailed Failures\n');
       this.printDetailedFailures();
-    }
-
-    if (!this.options.silent) {
-      const passed = this.testSummary.passed;
-      const failed = this.testSummary.failed;
-      const skipped = this.testSummary.skipped;
-
-      if (failed > 0) {
-        console.log(`\n  ${failed} failed`);
-        if (passed > 0) console.log(`  ${passed} passed`);
-        if (skipped > 0) console.log(`  ${skipped} skipped`);
-        console.log(`  ${this.testSummary.total} total`);
-        console.log(`  Finished in ${(this.testSummary.duration / 1000).toFixed(1)}s`);
-
-        const reportPath = path.join(this.reportsDir, 'all-failures.md');
-        console.log(`\n  📝 Detailed error report: ${reportPath}`);
-      } else {
-        console.log(`\n  ${passed} passed (${(this.testSummary.duration / 1000).toFixed(1)}s)`);
-      }
     }
   }
 


### PR DESCRIPTION
Implements issue #17 - Improve summary

This PR implements a new concise summary format that:
- Shows a one-line summary with pass/fail/skip counts
- Lists only failed and skipped tests with concise error details
- Removes verbose passed test output
- Provides better AI/CLI-friendly dense output

Closes #17

Generated with [Claude Code](https://claude.ai/code)